### PR TITLE
Don't forward arguments to make_format_args

### DIFF
--- a/src/lib/util/logger.hpp
+++ b/src/lib/util/logger.hpp
@@ -231,9 +231,9 @@ namespace logger {
         std::conditional_t<detail::wchar_str_view_t<Str>, std::wstring, std::string> msg; \
                                                                                           \
         if constexpr (detail::wchar_str_view_t<Str>) {                                    \
-            msg = std::vformat(fmt, std::make_wformat_args(std::forward<Args>(args)...)); \
+            msg = std::vformat(fmt, std::make_wformat_args(args...));                     \
         } else {                                                                          \
-            msg = std::vformat(fmt, std::make_format_args(std::forward<Args>(args)...));  \
+            msg = std::vformat(fmt, std::make_format_args(args...));                      \
         }                                                                                 \
                                                                                           \
         detail::log_line(Indentation, prefix, (color_fg).fg, (color_bg).bg, msg);         \


### PR DESCRIPTION
[P2905](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2905r2.html) retroactively makes passing an rvalue to make_format_args ill-formed.
This fix ensures that the project continues compiling with MSVC 17.10.3 that implemented the paper.